### PR TITLE
Implement scraping script with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# GetRealtors\n\nRun `python scraper.py` to scrape listings (requires network). Run `pytest` to execute tests.

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,73 @@
+import requests
+from lxml import html
+
+BASE_URL = "https://www.imovelweb.com.br/casas-venda-sao-paulo-sp-pagina-{}.html"
+
+
+def get_listing_links(pages=3):
+    links = []
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/125.0 Safari/537.36"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Referer": "https://www.google.com/",
+    }
+    for page in range(1, pages + 1):
+        url = BASE_URL.format(page)
+        print(f"Fetching page {page}: {url}")
+        resp = requests.get(url, headers=headers)
+        resp.raise_for_status()
+        tree = html.fromstring(resp.content)
+        index = 1
+        while True:
+            xpath = f"/html/body/div[1]/div[2]/div/div/div[1]/div[2]/div[2]/div[{index}]/div/div[1]/div[2]/div[1]/div[1]/h3/a"
+            nodes = tree.xpath(xpath)
+            if not nodes:
+                break
+            link = nodes[0].get('href')
+            if link and link not in links:
+                links.append(link)
+            index += 1
+    return links
+
+
+def extract_script_content(url, script_index=11):
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/125.0 Safari/537.36"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Referer": "https://www.google.com/",
+    }
+    resp = requests.get(url, headers=headers)
+    resp.raise_for_status()
+    tree = html.fromstring(resp.content)
+    xpath = f"/html/head/script[{script_index}]"
+    nodes = tree.xpath(xpath)
+    if nodes:
+        return nodes[0].text_content()
+    return ""
+
+
+def main():
+    links = get_listing_links(3)
+    print(f"Collected {len(links)} listing links")
+    data = []
+    for link in links:
+        print(f"Fetching listing: {link}")
+        content = extract_script_content(link)
+        data.append({"url": link, "script": content})
+    for item in data:
+        print(f"URL: {item['url']}")
+        print(f"Script:\n{item['script'][:200]}...\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,80 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import scraper
+from lxml import etree
+from types import SimpleNamespace
+from unittest import mock
+
+
+def build_sample_page(num_links=2):
+    """Build HTML with anchors located at the expected xpath."""
+    def ensure_child(parent, tag, index=None):
+        if index is None:
+            child = etree.SubElement(parent, tag)
+            return child
+        existing = [c for c in parent if c.tag == tag]
+        while len(existing) < index:
+            etree.SubElement(parent, tag)
+            existing = [c for c in parent if c.tag == tag]
+        return existing[index - 1]
+
+    root = etree.Element("html")
+    body = etree.SubElement(root, "body")
+    for i in range(1, num_links + 1):
+        parent = body
+        path = [
+            ("div", 1),
+            ("div", 2),
+            ("div", None),
+            ("div", None),
+            ("div", 1),
+            ("div", 2),
+            ("div", 2),
+            ("div", i),
+            ("div", None),
+            ("div", 1),
+            ("div", 2),
+            ("div", 1),
+            ("div", 1),
+            ("h3", None),
+            ("a", None),
+        ]
+        for tag, idx in path:
+            parent = ensure_child(parent, tag, idx)
+        parent.set("href", f"link{i}.html")
+        parent.text = f"Link {i}"
+    return etree.tostring(root, encoding="utf-8")
+
+
+def build_listing_page(script_text="DATA"):
+    root = etree.Element("html")
+    head = etree.SubElement(root, "head")
+    for i in range(1, 12):
+        s = etree.SubElement(head, "script")
+        s.text = f"script {i}"
+    head.xpath("//script[11]")[0].text = script_text
+    return etree.tostring(root, encoding="utf-8")
+
+
+class FakeResponse(SimpleNamespace):
+    def raise_for_status(self):
+        pass
+
+
+def test_get_listing_links():
+    html_bytes = build_sample_page(num_links=2)
+    with mock.patch("requests.get") as m:
+        m.return_value = FakeResponse(content=html_bytes)
+        links = scraper.get_listing_links(pages=1)
+        assert links == ["link1.html", "link2.html"]
+
+
+def test_extract_script_content():
+    html_bytes = build_listing_page(script_text="hello world")
+    with mock.patch("requests.get") as m:
+        m.return_value = FakeResponse(content=html_bytes)
+        text = scraper.extract_script_content("dummy")
+        assert "hello world" in text
+


### PR DESCRIPTION
## Summary
- implement `scraper.py` that retrieves listing links and extracts script info
- add `tests/test_scraper.py` with mocked HTTP responses
- document usage in README

## Testing
- `pip install pytest`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861d2b6de08832e9c1e8fe66856e62f