### PR TITLE
Use cloudscraper fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# GetRealtors\n\nRun `python scraper.py` to scrape listings (requires network). Run `pytest` to execute tests.
+# GetRealtors
+
+Install dependencies with `pip install -r requirements.txt`.
+Run `python scraper.py` to scrape listings (requires network).
+Run `pytest` to execute tests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+lxml
+cloudscraper


### PR DESCRIPTION
## Summary
- handle Cloudflare blocking by falling back to `cloudscraper` when a 403 is encountered
- add `requirements.txt` and update README with install instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d5bd1484832e85b90f89196a582f